### PR TITLE
Implement PWM Motor Simulation (TIM1)

### DIFF
--- a/inc/motor_pwm.h
+++ b/inc/motor_pwm.h
@@ -1,0 +1,238 @@
+/**
+ * @file    motor_pwm.h
+ * @brief   TIM1-CH1 PWM Motor Simulation Driver — STM32F4 @ 84 MHz
+ *
+ * @details Generates a 10 kHz PWM signal on PA8 (TIM1_CH1) to simulate
+ *          motor speed via LED brightness.  Three discrete speed states are
+ *          provided through the MotorSpeed_t enum; the duty cycle is updated
+ *          at run-time through a single non-blocking register write to CCR1.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │  CLOCK TREE (relevant path only)                                        │
+ * │                                                                         │
+ * │  SYSCLK 84 MHz ──► APB2 prescaler /1 ──► PCLK2 = 84 MHz               │
+ * │                                           │                             │
+ * │  APB2 prescaler = 1 → TIM1 multiplier ×1  │                             │
+ * │  (RM0368 §6.2: if APBx prescaler = 1,     │                             │
+ * │   timer clock = PCLK, NOT 2×PCLK)         │                             │
+ * │                                           ▼                             │
+ * │                                      TIM1_CLK = 84 MHz                 │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │  PWM MATH                                                               │
+ * │                                                                         │
+ * │  f_tick  = f_TIM  / (PSC + 1)                                          │
+ * │          = 84,000,000 / (83 + 1)  =  1,000,000 Hz  (1 µs per tick)    │
+ * │                                                                         │
+ * │  f_PWM   = f_tick / (ARR + 1)                                          │
+ * │          = 1,000,000 / (99 + 1)   = 10,000 Hz  ✓                      │
+ * │                                                                         │
+ * │  Duty %  = CCR1 / (ARR + 1)  × 100                                    │
+ * │          CCR1 =  0 →   0 %  (motor stopped)                            │
+ * │          CCR1 = 20 →  20 %  (motor slow)                               │
+ * │          CCR1 = 100 → 100 % (motor full — force-high via CCR1 > ARR)   │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * @note    Motor_PWM_Init() assumes RCC clocks for GPIOA and TIM1 have
+ *          already been enabled (by Peripheral_Clocks_Enable() in rcc_config.c).
+ *
+ * @note    The 100 % state is achieved by writing CCR1 = ARR + 1 = 100,
+ *          which forces the output permanently high in PWM mode 1.
+ *          This is the correct, hardware-documented approach (RM0368 §18.3.9).
+ *
+ * @author  Elite Staff Embedded Engineer
+ * @version 1.0.0
+ */
+
+#ifndef MOTOR_PWM_H
+#define MOTOR_PWM_H
+
+#include <stdint.h>
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * CLOCK & TIMER CONSTANTS  (derived from rcc_config.h values)
+ *
+ * Defined here independently so motor_pwm.c is a self-contained module
+ * that documents its own assumptions.  Must stay in sync with rcc_config.h.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/** TIM1 input clock frequency (Hz).  APB2 prescaler = /1 → TIM1_CLK = PCLK2. */
+#define MOTOR_TIM_CLK_HZ        (84000000UL)
+
+/** Target PWM output frequency (Hz). */
+#define MOTOR_PWM_FREQ_HZ       (10000UL)
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * PSC / ARR / CCR1 REGISTER VALUES
+ *
+ * Derived from the formula:
+ *   PSC  = (f_TIM / (f_tick))       - 1   where f_tick is chosen as 1 MHz
+ *   ARR  = (f_tick / f_PWM)         - 1
+ *   CCR1 = (duty_percent / 100) × (ARR + 1)
+ *
+ * These constants are used in Motor_PWM_Init() and serve as documentation
+ * for any reader who wants to verify the math without opening the .c file.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Prescaler register value.
+ *
+ * f_tick = 84,000,000 / (83 + 1) = 1,000,000 Hz  (1 µs/tick).
+ * Written to TIM1->PSC.  Hardware adds 1 internally, so the divisor is 84.
+ */
+#define MOTOR_TIM_PSC           (83U)
+
+/**
+ * @brief Auto-reload register value (defines the PWM period).
+ *
+ * f_PWM = 1,000,000 / (99 + 1) = 10,000 Hz.
+ * The counter counts 0..99 (100 ticks per period = 100 µs).
+ * Written to TIM1->ARR.
+ */
+#define MOTOR_TIM_ARR           (99U)
+
+/**
+ * @brief CCR1 value for 0 % duty cycle (motor stopped).
+ *
+ * In PWM mode 1: output is HIGH while CNT < CCR1.
+ * CCR1 = 0 → CNT is never < 0 → output is always LOW → 0 % duty.
+ */
+#define MOTOR_CCR1_STOP         (0U)
+
+/**
+ * @brief CCR1 value for 20 % duty cycle (motor slow).
+ *
+ * CNT < 20 → HIGH (20 ticks out of 100) → 20 % duty.
+ * Represents low-speed / creep motion.
+ */
+#define MOTOR_CCR1_SLOW         (20U)
+
+/**
+ * @brief CCR1 value for 100 % duty cycle (motor full speed).
+ *
+ * CCR1 = ARR + 1 = 100.
+ * RM0368 §18.3.9: When CCR1 > ARR in PWM mode 1, the output is
+ * permanently forced HIGH → 100 % duty cycle without counter wrap artefacts.
+ */
+#define MOTOR_CCR1_FULL         (MOTOR_TIM_ARR + 1U)   /* = 100 */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * REGISTER BIT CONSTANTS  (named aliases for every magic number)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── GPIOA MODER: PA8 alternate-function mode (MODER bits[17:16] = 10) ── */
+#define PA8_MODER_BIT_POS       (16U)          /* MODER8[1:0] starts at bit 16 */
+#define PA8_MODER_AF_MODE       (0x2U)         /* 10b = Alternate Function mode */
+#define PA8_MODER_MASK          (0x3U << PA8_MODER_BIT_POS)
+
+/* ── GPIOA OSPEEDR: PA8 high speed (OSPEEDR8[1:0] = 10) ── */
+#define PA8_OSPEEDR_BIT_POS     (16U)
+#define PA8_OSPEEDR_HIGH        (0x2U)         /* 10b = high speed */
+#define PA8_OSPEEDR_MASK        (0x3U << PA8_OSPEEDR_BIT_POS)
+
+/* ── GPIOA PUPDR: PA8 no pull (PUPDR8[1:0] = 00) ── */
+#define PA8_PUPDR_BIT_POS       (16U)
+#define PA8_PUPDR_NONE          (0x0U)
+#define PA8_PUPDR_MASK          (0x3U << PA8_PUPDR_BIT_POS)
+
+/**
+ * @brief Alternate Function 1 (TIM1_CH1) selector for PA8 in AFRH.
+ *
+ * PA8 is in the HIGH alternate-function register (AFRH = AFR[1]).
+ * AF1 = 0x1 occupies bits [3:0] of AFRH (i.e. AFRH[8-8] = pin 8 offset 0).
+ * AFRH pin offset: pin_number - 8.  PA8 → offset = 0 → bits [3:0].
+ */
+#define PA8_AFRH_BIT_POS        (0U)           /* (8 - 8) × 4 = 0 */
+#define PA8_AFRH_AF1            (0x1U)         /* AF1 = TIM1/TIM2 */
+#define PA8_AFRH_MASK           (0xFU << PA8_AFRH_BIT_POS)
+
+/* ── TIM1 CCMR1: OC1M[2:0] = 110b = PWM mode 1, at bits [6:4] ── */
+#define TIM1_CCMR1_OC1M_PWM1   (6U << 4U)     /* PWM mode 1: active while CNT < CCR1 */
+#define TIM1_CCMR1_OC1PE        (1U << 3U)     /* OC1 preload enable (recommended) */
+#define TIM1_CCMR1_OC1M_MASK   (7U << 4U)     /* OC1M field mask */
+
+/* ── TIM1 CCER: CC1E [bit 0] = Capture/Compare 1 output enable ── */
+#define TIM1_CCER_CC1E          (1U << 0U)
+
+/* ── TIM1 BDTR: MOE [bit 15] = Main Output Enable (mandatory for advanced timers) ── */
+#define TIM1_BDTR_MOE           (1U << 15U)
+
+/* ── TIM1 CR1: ARPE [bit 7] = Auto-reload preload enable ── */
+#define TIM1_CR1_ARPE           (1U << 7U)
+
+/* ── TIM1 CR1: CEN [bit 0] = Counter enable ── */
+#define TIM1_CR1_CEN            (1U << 0U)
+
+/* ── TIM1 EGR: UG [bit 0] = Update generation (force PSC/ARR reload) ── */
+#define TIM1_EGR_UG             (1U << 0U)
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * MOTOR SPEED ENUM
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Discrete motor speed states for the elevator simulation.
+ *
+ * These map directly to the three CCR1 duty-cycle values defined above.
+ * The numeric values are NOT written to registers — Motor_SetSpeed() uses
+ * a switch-case to translate them to the correct CCR1 constant.
+ *
+ * Usage:
+ * @code
+ *   Motor_SetSpeed(MOTOR_STOP);   // LED off  — elevator stationary
+ *   Motor_SetSpeed(MOTOR_SLOW);   // LED dim  — elevator approaching floor
+ *   Motor_SetSpeed(MOTOR_FULL);   // LED full — elevator in transit
+ * @endcode
+ */
+typedef enum
+{
+    MOTOR_STOP  = 0,    /**< 0 %  duty — motor off, elevator stationary.    */
+    MOTOR_SLOW  = 1,    /**< 20 % duty — low speed (deceleration / startup). */
+    MOTOR_FULL  = 2     /**< 100 % duty — full speed, elevator in transit.   */
+} MotorSpeed_t;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * FUNCTION DECLARATIONS
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief  Initialise TIM1-CH1 for 10 kHz PWM on PA8.
+ *
+ * @details Performs, in order:
+ *          1. Configure PA8: AF mode, AF1 selection, high speed, no pull.
+ *          2. Set TIM1->PSC = 83  (f_tick = 1 MHz).
+ *          3. Set TIM1->ARR = 99  (f_PWM  = 10 kHz).
+ *          4. Set TIM1->CCR1 = 0  (start stopped).
+ *          5. Configure CCMR1: PWM mode 1, OC1 preload enable.
+ *          6. Configure CCER: enable CC1 output.
+ *          7. Configure BDTR: set MOE (Main Output Enable — mandatory for TIM1).
+ *          8. Configure CR1:  enable ARPE, generate UG update event, start counter.
+ *
+ * @pre    RCC clocks for GPIOA and TIM1 must be enabled before calling
+ *         (handled by Peripheral_Clocks_Enable() in rcc_config.c).
+ *
+ * @note   This function does NOT enable or configure any NVIC interrupt.
+ *         PWM generation is fully hardware-driven once the counter is running.
+ *
+ * @note   After this call the motor is in MOTOR_STOP state (CCR1 = 0).
+ *         Call Motor_SetSpeed() to change the duty cycle.
+ */
+void Motor_PWM_Init(void);
+
+/**
+ * @brief  Set the motor simulation speed by updating TIM1->CCR1.
+ *
+ * @details This is a non-blocking, single-register write.  The new duty
+ *          cycle takes effect at the next counter update event (end of the
+ *          current 100 µs PWM period) because OC1 preload is enabled.
+ *
+ * @param[in] speed  Desired motor speed state from the MotorSpeed_t enum.
+ *
+ * @note   Safe to call from ISR context — the write to CCR1 is atomic on
+ *         the 32-bit AHB bus and the timer preload mechanism prevents
+ *         mid-period glitches.
+ */
+void Motor_SetSpeed(MotorSpeed_t speed);
+
+#endif /* MOTOR_PWM_H */

--- a/src/motor_pwm.c
+++ b/src/motor_pwm.c
@@ -1,0 +1,317 @@
+/**
+ * @file    motor_pwm.c
+ * @brief   TIM1-CH1 PWM Motor Simulation Driver — Implementation
+ *
+ * @details Two functions implement the complete PWM motor simulation:
+ *
+ *          Motor_PWM_Init()
+ *          ─────────────────
+ *          Configures PA8 as TIM1_CH1 (AF1) and programs TIM1 for
+ *          10 kHz PWM output.  Register writes are performed in the exact
+ *          order mandated by RM0368 §18.3.8 ("PWM output mode").
+ *
+ *          Mandatory initialisation order (RM0368 §18.3.8):
+ *            1. GPIO alternate-function setup (before timer starts).
+ *            2. Set PSC and ARR (timing backbone — set while counter off).
+ *            3. Set CCR1 (initial duty = 0 %).
+ *            4. Set CCMR1.OC1M (output compare mode).
+ *            5. Set CCMR1.OC1PE (output-compare preload — mandatory for glitch-free
+ *               run-time updates; RM0368 §18.3.9 states preload must be enabled).
+ *            6. Set CCER.CC1E (enable channel output).
+ *            7. Set BDTR.MOE  (Main Output Enable — TIM1-specific; output stays low
+ *               without this bit regardless of CCER; RM0368 §18.4.18).
+ *            8. Set CR1.ARPE  (auto-reload preload).
+ *            9. Write EGR.UG  (force update event — latches PSC/ARR/CCR1
+ *               into their shadow registers; RM0368 §18.4.6).
+ *           10. Set CR1.CEN   (start counter — last step, after all config).
+ *
+ *          Motor_SetSpeed()
+ *          ──────────────────
+ *          Single CCR1 write, translated via a switch-case from the
+ *          MotorSpeed_t enum.  The OC1 preload mechanism ensures the new
+ *          duty cycle is loaded at the next update event (UEV), preventing
+ *          a mid-period glitch if the write happens during a PWM cycle.
+ *
+ * @author  Elite Staff Embedded Engineer
+ * @version 1.0.0
+ */
+
+#include "motor_pwm.h"
+#include "stm32f4xx.h"   /* CMSIS: GPIOA, TIM1 register structs */
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * STATIC ASSERTIONS — catch configuration errors at compile time
+ *
+ * These fire a compile error if the PSC/ARR constants produce a frequency
+ * other than 10 kHz, or if CCR1 values exceed ARR+1.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Verify PSC yields exactly 1 MHz tick rate from 84 MHz input clock. */
+_Static_assert(
+    (MOTOR_TIM_CLK_HZ / (MOTOR_TIM_PSC + 1U)) == 1000000UL,
+    "PSC constant does not produce a 1 MHz tick frequency from 84 MHz TIM_CLK"
+);
+
+/* Verify ARR yields exactly 10 kHz PWM from the 1 MHz tick rate. */
+_Static_assert(
+    (MOTOR_TIM_CLK_HZ / (MOTOR_TIM_PSC + 1U)) / (MOTOR_TIM_ARR + 1U) == MOTOR_PWM_FREQ_HZ,
+    "ARR constant does not produce 10 kHz PWM from 1 MHz tick frequency"
+);
+
+/* Verify duty-cycle CCR1 values are within the valid range [0, ARR+1]. */
+_Static_assert(MOTOR_CCR1_STOP <= (MOTOR_TIM_ARR + 1U),
+    "MOTOR_CCR1_STOP exceeds ARR+1");
+_Static_assert(MOTOR_CCR1_SLOW <= (MOTOR_TIM_ARR + 1U),
+    "MOTOR_CCR1_SLOW exceeds ARR+1");
+_Static_assert(MOTOR_CCR1_FULL <= (MOTOR_TIM_ARR + 1U),
+    "MOTOR_CCR1_FULL exceeds ARR+1");
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Motor_PWM_Init
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+void Motor_PWM_Init(void)
+{
+    /* ── 1a. Configure PA8: set MODER8[1:0] = 10 (Alternate Function) ─────
+     *
+     * GPIOA->MODER is a 32-bit register with 2 bits per pin:
+     *   00 = Input, 01 = Output, 10 = Alternate Function, 11 = Analog
+     *
+     * PA8 occupies MODER[17:16].  We clear both bits with the mask, then
+     * OR in the AF mode value (0x2 << 16).
+     *
+     * Read-modify-write preserves the existing state of all other GPIO pins.
+     */
+    GPIOA->MODER &= ~PA8_MODER_MASK;
+    GPIOA->MODER |=  (PA8_MODER_AF_MODE << PA8_MODER_BIT_POS);
+
+    /* ── 1b. Configure PA8: output speed = high ───────────────────────────
+     *
+     * OSPEEDR8[1:0] = 10 → high speed (suitable for 10 kHz PWM slew rate).
+     * PWM at 10 kHz has a period of 100 µs; even the low-speed setting
+     * (OSPEEDR = 00, ~2 MHz) would be adequate, but high speed is preferred
+     * for a clean square-wave edge on a simulation LED.
+     */
+    GPIOA->OSPEEDR &= ~PA8_OSPEEDR_MASK;
+    GPIOA->OSPEEDR |=  (PA8_OSPEEDR_HIGH << PA8_OSPEEDR_BIT_POS);
+
+    /* ── 1c. Configure PA8: no pull-up / pull-down ────────────────────────
+     *
+     * PUPDR8[1:0] = 00 → floating.  The TIM1 peripheral drives the line
+     * directly; an external pull would interfere with the duty cycle.
+     */
+    GPIOA->PUPDR &= ~PA8_PUPDR_MASK;
+    /* PA8_PUPDR_NONE = 0x0 → no bits need to be set; mask-clear is enough. */
+
+    /* ── 1d. Configure PA8: Alternate Function 1 (TIM1_CH1) via AFRH ─────
+     *
+     * STM32F4 GPIO has two AFR registers:
+     *   AFRL (AFR[0]) → pins 0–7
+     *   AFRH (AFR[1]) → pins 8–15
+     *
+     * PA8 is in AFRH.  Each pin uses 4 bits; PA8 occupies AFRH[3:0]
+     * (bit position = (pin_number - 8) × 4 = (8-8)×4 = 0).
+     *
+     * AF1 = 0x1 selects TIM1_CH1 / TIM2_CH1 (RM0368 Table 9).
+     * AF1 is the ONLY valid alternate function for TIM1_CH1 on PA8.
+     *
+     * MUST be configured BEFORE the timer counter starts, otherwise the
+     * GPIO input/output model during the first PWM cycles is undefined.
+     */
+    GPIOA->AFR[1] &= ~PA8_AFRH_MASK;
+    GPIOA->AFR[1] |=  (PA8_AFRH_AF1 << PA8_AFRH_BIT_POS);
+
+    /* ── 2. Program PSC: prescaler sets tick frequency to 1 MHz ──────────
+     *
+     * TIM1->PSC = 83 → counter tick rate = 84,000,000 / (83+1) = 1,000,000 Hz
+     *
+     * PSC is buffered: the new value is loaded at the next update event (UG).
+     * The actual reload happens in step 9 (EGR.UG write).
+     */
+    TIM1->PSC = MOTOR_TIM_PSC;       /* = 83 */
+
+    /* ── 3. Program ARR: auto-reload sets PWM period to 100 µs (10 kHz) ──
+     *
+     * TIM1->ARR = 99 → counter cycles 0..99 = 100 ticks × 1 µs = 100 µs period
+     *           → f_PWM = 1,000,000 / 100 = 10,000 Hz ✓
+     *
+     * ARR is also buffered (shadow register).  The value is used after UG.
+     */
+    TIM1->ARR = MOTOR_TIM_ARR;       /* = 99 */
+
+    /* ── 4. Program CCR1: initial duty cycle = 0 % (motor stopped) ────────
+     *
+     * In PWM mode 1: output is HIGH while CNT < CCR1.
+     * CCR1 = 0 → CNT is never < 0 → output always LOW → 0 % duty.
+     *
+     * CCR1 has a preload shadow register when OC1PE is set (see step 5b).
+     * The preloaded value is latched after UG.
+     */
+    TIM1->CCR1 = MOTOR_CCR1_STOP;    /* = 0 */
+
+    /* ── 5a. Configure CCMR1: set OC1M[2:0] = 110 (PWM mode 1) ───────────
+     *
+     * CCMR1 register layout (output compare mode for CH1):
+     *   bits [1:0]  CC1S  = 00   → CH1 configured as output (required for PWM)
+     *   bit  [2]    OC1FE = 0    → fast enable off (not needed for LED PWM)
+     *   bit  [3]    OC1PE = set in step 5b
+     *   bits [6:4]  OC1M  = 110  → PWM mode 1
+     *   bit  [7]    OC1CE = 0    → clear disabled
+     *
+     * CC1S must be 00 (output) for OC1M to control the output pin.
+     * We clear the entire OC1M field first, then OR in the mode value.
+     * The CC1S bits start as 00 at reset and are not touched here.
+     *
+     * PWM mode 1 (OC1M = 110):
+     *   Channel is active (HIGH) while CNT < CCR1 (upcounting mode).
+     *   Channel is inactive (LOW)  while CNT ≥ CCR1.
+     */
+    TIM1->CCMR1 &= ~TIM1_CCMR1_OC1M_MASK;       /* Clear OC1M[2:0]       */
+    TIM1->CCMR1 |=  TIM1_CCMR1_OC1M_PWM1;       /* Set  OC1M = 110b      */
+
+    /* ── 5b. Enable OC1 preload (OC1PE bit 3) ─────────────────────────────
+     *
+     * RM0368 §18.3.9 (PWM mode — note): "As the preload registers are
+     * transferred to the shadow registers only when an update event occurs,
+     * before starting the counter, you have to initialize all the registers
+     * by setting the UG bit in the TIMx_EGR register."
+     *
+     * With OC1PE = 1:
+     *   Writes to CCR1 go into the preload register.
+     *   The preload value is transferred to the active CCR1 shadow at UEV.
+     *   This guarantees that a Motor_SetSpeed() call mid-period does not
+     *   cause a partial-period glitch — the duty change only takes effect
+     *   at the next clean period boundary.
+     */
+    TIM1->CCMR1 |= TIM1_CCMR1_OC1PE;
+
+    /* ── 6. Enable Capture/Compare channel 1 output (CCER.CC1E) ──────────
+     *
+     * TIM1->CCER bit 0 = CC1E:
+     *   0 → CC1 output is disabled (pin driven by GPIO logic).
+     *   1 → CC1 output is enabled  (pin driven by timer compare output).
+     *
+     * CC1P (bit 1) = 0 (default) → active HIGH polarity (output HIGH when
+     * CNT < CCR1).  Not modified — reset default is correct.
+     */
+    TIM1->CCER |= TIM1_CCER_CC1E;
+
+    /* ── 7. Enable Main Output (BDTR.MOE — Advanced Timer TIM1 specific) ──
+     *
+     * TIM1 is an "advanced-control timer."  It has a Break and Dead-Time
+     * Register (BDTR) that includes a global output gate called MOE
+     * (Main Output Enable), bit 15.
+     *
+     * Without MOE = 1, ALL TIM1 outputs remain at their idle/reset level
+     * regardless of CCER.CC1E, CCMR1, or the running counter.  This is
+     * a safety feature for motor-drive applications with dead-time control.
+     *
+     * For this simulation we have no break input, so MOE is set
+     * unconditionally.  General-purpose timers (TIM2–TIM5) do NOT have
+     * this register and do NOT require this step.
+     */
+    TIM1->BDTR |= TIM1_BDTR_MOE;
+
+    /* ── 8. Enable Auto-Reload Preload (CR1.ARPE) ─────────────────────────
+     *
+     * With ARPE = 1, writes to TIM1->ARR go into the ARR shadow register
+     * and are applied at the next UEV.  This prevents a mid-period counter
+     * overflow anomaly if ARR is ever updated at run-time.
+     *
+     * For this project ARR is never changed, but enabling ARPE is best
+     * practice for all PWM applications (RM0368 §18.3.1).
+     */
+    TIM1->CR1 |= TIM1_CR1_ARPE;
+
+    /* ── 9. Generate Update Event (EGR.UG) — latch all shadow registers ───
+     *
+     * Writing UG = 1 forces an immediate update event.  This causes:
+     *   • PSC shadow register  ← TIM1->PSC  (83)
+     *   • ARR shadow register  ← TIM1->ARR  (99)
+     *   • CCR1 shadow register ← TIM1->CCR1 (0)
+     *
+     * Without this step, the shadow registers retain their reset values
+     * (PSC=0, ARR=0xFFFF) until the first natural overflow, which could
+     * produce an incorrect PWM period or duty cycle for the first few
+     * hundred milliseconds of operation.
+     *
+     * UG is cleared by hardware immediately after the update event.
+     * The UIF interrupt flag (SR bit 0) is also set by UG — but because
+     * no interrupt is enabled for TIM1 Update in this project's NVIC
+     * configuration, the flag is harmless.  We clear it explicitly to avoid
+     * a spurious interrupt if the NVIC is later enabled for other TIM1 events.
+     */
+    TIM1->EGR  |= TIM1_EGR_UG;
+    TIM1->SR   &= ~(1U << 0U);   /* Clear UIF flag set by the UG write */
+
+    /* ── 10. Start the counter (CR1.CEN) ──────────────────────────────────
+     *
+     * CEN is set LAST — after all configuration is complete and shadow
+     * registers have been initialised by the UG event.
+     *
+     * From this point the counter runs continuously at 1 MHz, overflowing
+     * every 100 µs.  PA8 outputs a 10 kHz PWM signal at 0 % duty cycle.
+     * Motor_SetSpeed() changes the duty in real time.
+     */
+    TIM1->CR1 |= TIM1_CR1_CEN;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Motor_SetSpeed
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @brief Set motor speed by updating the TIM1 capture/compare register.
+ *
+ * @details The switch-case translates the human-readable enum into the
+ *          exact CCR1 value.  Writing to CCR1 when OC1PE = 1 updates the
+ *          preload register; the new duty cycle is applied at the next UEV
+ *          (i.e. when the 100 µs counter period ends), preventing glitches.
+ *
+ *          This function is ISR-safe: the single 32-bit write to CCR1 is
+ *          atomic on the AHB bus, and the timer preload eliminates the race
+ *          condition between a CCR1 write and the counter position.
+ *
+ * @param speed  MOTOR_STOP → CCR1 = 0  (0 % duty)
+ *               MOTOR_SLOW → CCR1 = 20 (20 % duty)
+ *               MOTOR_FULL → CCR1 = 100 (100 % duty, forced-high)
+ */
+void Motor_SetSpeed(MotorSpeed_t speed)
+{
+    uint32_t ccr1_value;
+
+    switch (speed)
+    {
+        case MOTOR_STOP:
+            /* 0 % duty — elevator stationary, LED fully off.
+             * CNT is never < 0, so output stays LOW for the full period. */
+            ccr1_value = MOTOR_CCR1_STOP;   /* = 0 */
+            break;
+
+        case MOTOR_SLOW:
+            /* 20 % duty — elevator decelerating or door-zone creep.
+             * Output HIGH for ticks 0–19 (20 ticks), LOW for ticks 20–99. */
+            ccr1_value = MOTOR_CCR1_SLOW;   /* = 20 */
+            break;
+
+        case MOTOR_FULL:
+            /* 100 % duty — elevator in full-speed transit.
+             * CCR1 = ARR + 1 = 100.  In PWM mode 1, when CCR1 > ARR the
+             * output is forced permanently HIGH for the entire period.
+             * RM0368 §18.3.9: "If CCR1 ≥ ARR+1, the output is always active." */
+            ccr1_value = MOTOR_CCR1_FULL;   /* = 100 */
+            break;
+
+        default:
+            /* Defensive: unknown state → stop motor immediately.
+             * This branch is unreachable with a well-typed caller but guards
+             * against bit corruption of the speed argument in a fault scenario. */
+            ccr1_value = MOTOR_CCR1_STOP;   /* = 0 */
+            break;
+    }
+
+    /* Single 32-bit write — atomic on the AHB bus.
+     * The OC1 preload mechanism ensures this is applied at the next UEV,
+     * not mid-period.  No critical section is needed. */
+    TIM1->CCR1 = ccr1_value;
+}


### PR DESCRIPTION
This PR implements the bare-metal TIM1 driver for the 10kHz motor simulation. It provides a clean, ISR-safe Motor_SetSpeed() API. Closes #6.